### PR TITLE
I've updated `ACCESS_TOKEN_EXPIRE_MINUTES` to effectively remove the …

### DIFF
--- a/mtg-collection-backend/app/core/config.py
+++ b/mtg-collection-backend/app/core/config.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 class Settings(BaseSettings):
     DATABASE_URL: str
     SECRET_KEY: str = "your_default_secret_key_please_change_in_env" # Should be overridden by .env
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30 # Default to 30 minutes
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 5256000 # Default to 30 minutes
 
     class Config:
         env_file = ".env" # Specifies the .env file to load variables from


### PR DESCRIPTION
…login timeout for you.

I changed `ACCESS_TOKEN_EXPIRE_MINUTES` in `app/core/config.py` to `5256000` (which is 10 years in minutes) so you can stay logged in for the duration of the cookie.